### PR TITLE
fix error in installation instructions for requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A native music player for Haiku.
 Install via `pkgman`:
 
 ```bash
-pkgman install taglib_devel libmusicbrainz_devel
+pkgman install taglib_devel musicbrainz_devel
 ```
 
 ## Building


### PR DESCRIPTION
the development package for the musicbrainz library is called musicbrainz_devel instead of libmusicbrainz_devel